### PR TITLE
The MOE_SDK_JAVA8SUPPORT_JAR artifact shall also be skipped

### DIFF
--- a/src/main/java/org/moe/maven/BuildGradleTask.java
+++ b/src/main/java/org/moe/maven/BuildGradleTask.java
@@ -129,7 +129,8 @@ public abstract class BuildGradleTask extends GradleTask {
             for (Artifact artifact : artifacts) {
                 if (artifact.getArtifactId().equals(SetupSDKTask.MOE_SDK_PLATFORM_JAR) || artifact.getArtifactId()
                         .equals(SetupSDKTask.MOE_SDK_CORE_JAR) || artifact.getArtifactId()
-                        .equals(SetupSDKTask.MOE_SDK_JUNIT_JAR)) {
+                        .equals(SetupSDKTask.MOE_SDK_JUNIT_JAR) || artifact.getArtifactId()
+                        .equals(SetupSDKTask.MOE_SDK_JAVA8SUPPORT_JAR)) {
 
                     continue;
                 }


### PR DESCRIPTION
When the `MOE_SDK_JAVA8SUPPORT_JAR` was added in [81c57552a804](https://github.com/multi-os-engine/moe-plugin-maven/commit/81c57552a804f8f9a5422cedf442e1cd85142251) - the `BuildGradleTask` should have probably also be modified to skip this artifact, like the other ones.

Please consider this change. Without it my build yields a (non-fatal, but visible) error:
```bash

org.apache.maven.artifact.resolver.ArtifactNotFoundException: System artifact: moe.sdk:moe.sdk.java8support:jar:1.0:system has no file attached

Try downloading the file manually from the project website.

Then, install it using the command: 
    mvn install:install-file -DgroupId=moe.sdk -DartifactId=moe.sdk.java8support -Dversion=1.0 -Dpackaging=jar -Dfile=/path/to/file

Alternatively, if you host your own repository you can deploy the file there: 
    mvn deploy:deploy-file -DgroupId=moe.sdk -DartifactId=moe.sdk.java8support -Dversion=1.0 -Dpackaging=jar -Dfile=/path/to/file -Durl=[url] -DrepositoryId=[id]


  moe.sdk:moe.sdk.java8support:jar:1.0


	at org.apache.maven.artifact.resolver.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:180)
	at org.apache.maven.artifact.resolver.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:157)
	at org.apache.maven.artifact.resolver.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:525)
	at org.moe.maven.BuildGradleTask.getDependencies(BuildGradleTask.java:139)
	at org.moe.maven.BuildGradleTask.addInjars(BuildGradleTask.java:99)
	at org.moe.maven.BuildGradleTask.addArguments(BuildGradleTask.java:73)
	at org.moe.maven.GradleTask.execute(GradleTask.java:151)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:320)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)
```